### PR TITLE
Update dependency browserify to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babelify": "^8.0.0",
-    "browserify": "^15.2.0",
+    "browserify": "^16.0.0",
     "debug": "^3.1.0",
     "eslint": "^4.16.0",
     "eslint-plugin-react": "^7.5.1",


### PR DESCRIPTION
This Pull Request updates dependency [browserify](https://github.com/browserify/browserify) from `^15.2.0` to `^16.0.0`



<details>
<summary>Release Notes</summary>

### [`v16.0.0`](https://github.com/browserify/browserify/blob/master/CHANGELOG.md#&#8203;1600)

add `--preserve-symlinks` option from Node 6.3

`https://github.com/browserify/browserify/pull/1742`
`https://github.com/browserify/browserify/pull/1801`

update the browser version of `events` to 2.0.0—this version adds methods like `prependListener` that were introduced in recent node versions, but it is also twice the size of events v1.x (2KB instead of 1KB).

`https://github.com/browserify/browserify/pull/1803`

Dynamically calculate `__dirname` and `__filename` when `--node` is passed

`https://github.com/browserify/browserify/pull/1725`

upgrade module-deps, see https://github.com/browserify/module-deps/releases/tag/v6.0.0

https://github.com/browserify/browserify/commit/e5e1ec8799f1007a56118ae46646e0048385ed84

---

### [`v16.1.0`](https://github.com/browserify/browserify/blob/master/CHANGELOG.md#&#8203;1610)

add `bare` and `node` options to the API, same as the `--bare` and `--node` CLI arguments.

`https://github.com/browserify/browserify/pull/1804`

---

### [`v16.1.1`](https://github.com/browserify/browserify/blob/master/CHANGELOG.md#&#8203;1611)

add empty stub for the `perf_hooks` builtin module.

`https://github.com/browserify/browserify/pull/1815`

---

### [`v16.2.0`](https://github.com/browserify/browserify/blob/master/CHANGELOG.md#&#8203;1620)

update the browser versions of `vm-browserify` and `string_decoder`.

`string_decoder` updates to the Node 8+ API.
`vm-browserify` replaces an unlicensed dependency by an MIT one.

`https://github.com/browserify/browserify/pull/1829`

---

</details>


<details>
<summary>Commits</summary>

#### v16.0.0
-   [`2b9b319`](https://github.com/browserify/browserify/commit/2b9b31904be01bd67f26db4232c376572bbd366f) Merge pull request #&#8203;1742 from devongovett/preserve-symlinks
-   [`59e4642`](https://github.com/browserify/browserify/commit/59e464242a827fb36b03976eba40fda8b6539822) Always resolve initial link
-   [`7c81aea`](https://github.com/browserify/browserify/commit/7c81aeafd988b2d9c510dcdbc64bc6eb7cf79954) Upgrade builtin modules
-   [`2fc049e`](https://github.com/browserify/browserify/commit/2fc049e9f006a90c5a9331d7b9f21ba93bcb34ed) Merge pull request #&#8203;1801 from browserify/resolve-initial-link
-   [`b38b709`](https://github.com/browserify/browserify/commit/b38b709e40203aecf3da53723cce6d3493a0d297) Merge pull request #&#8203;1803 from browserify/bump-versions
-   [`2a574e4`](https://github.com/browserify/browserify/commit/2a574e45fb41f57cc5c931cdc1e6a70bc06f8c86) Merge pull request #&#8203;1725 from jviotti/dynamic-dirname-filename
-   [`e5e1ec8`](https://github.com/browserify/browserify/commit/e5e1ec8799f1007a56118ae46646e0048385ed84) Upgrade module-deps
-   [`01f3591`](https://github.com/browserify/browserify/commit/01f35914712900d3dd76f61c3bb374f1a0fb21fb) 16.0.0
#### v16.1.0
-   [`38141f1`](https://github.com/browserify/browserify/commit/38141f1ed6fc481704abcf9d76f1b3b2e65d2d00) Add MIT license text, fixes #&#8203;1069
-   [`b233840`](https://github.com/browserify/browserify/commit/b233840cfd6928cadfa101c13507cd9de0c91d26) Move `bare` and `node` options into API.
-   [`7260e36`](https://github.com/browserify/browserify/commit/7260e365008976055213589245b71687968297c3) Merge pull request #&#8203;1804 from browserify/cli-args
-   [`61c1994`](https://github.com/browserify/browserify/commit/61c19943e78a5d7663603b43ad6c31985c9186cc) 16.1.0
#### v16.1.1
-   [`680d0e6`](https://github.com/browserify/browserify/commit/680d0e67dfa6dc7063fb4cacaa144e291b467001) test/bare.js: fix file path
-   [`1ab192c`](https://github.com/browserify/browserify/commit/1ab192c14cfe435dbbd35ddeb3e73a20b1ea801c) test/bare.js: nits
-   [`989cc56`](https://github.com/browserify/browserify/commit/989cc565831867919301c4f6533ecdf54e3b09e5) Fix tests on Node &lt;0.10
-   [`d430656`](https://github.com/browserify/browserify/commit/d4306564482f1663c3328594ad879b264818bf74) explicitly mention to use ./ in require() for local files, closes #&#8203;1774
-   [`8bbddf7`](https://github.com/browserify/browserify/commit/8bbddf73c3296d8c54252267d5e87828eb28e1ac) Merge pull request #&#8203;1810 from al-k21/bare-fix
-   [`99f86dc`](https://github.com/browserify/browserify/commit/99f86dcbee9f2ce8d088568b55e5efdf7dd58545) Merge pull request #&#8203;1811 from browserify/node-0.10-tests
-   [`a3a3e9c`](https://github.com/browserify/browserify/commit/a3a3e9c849ce251f59fcf05fd8398a3c3c1f0d09) ignore perf_hooks
-   [`fa00040`](https://github.com/browserify/browserify/commit/fa00040996e5d29e484f5f8dbdff37647d20507b) Merge pull request #&#8203;1815 from browserify/ignore-perf-hooks
#### v16.2.0
-   [`25c71db`](https://github.com/browserify/browserify/commit/25c71dbd9425b4a0aa811029d5a4b1d062d75395) 16.1.1
-   [`9345e21`](https://github.com/browserify/browserify/commit/9345e2186d98350b864afb730b9520684229a436) Update string_decoder and vm builtin modules
-   [`03ffac9`](https://github.com/browserify/browserify/commit/03ffac986cbbd71af000f5f4b6dee18ec27babd6) ci: Disable certificate check for very old npm
-   [`e333b14`](https://github.com/browserify/browserify/commit/e333b14752463dd5e1772b271994c02574500ed0) Merge pull request #&#8203;1827 from browserify/fix-cert
-   [`7005b6e`](https://github.com/browserify/browserify/commit/7005b6edcc7452ca589b17994b1ec143b430d42a) Merge pull request #&#8203;1829 from browserify/deps
-   [`00cc377`](https://github.com/browserify/browserify/commit/00cc377939e2434b321fd0c4253b882a6b5f1280) 16.2.0

</details>