### PR TITLE
Update dependency firebase to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "firebase": "^4.9.0",
+    "firebase": "^5.0.0",
     "jquery": "^3.3.1",
     "react": "^16.2.0",
     "reactfire": "^1.0.0",
@@ -33,7 +33,7 @@
     "debug": "^3.1.0",
     "eslint": "^4.16.0",
     "eslint-plugin-react": "^7.5.1",
-    "firebase": "^4.9.0",
+    "firebase": "^5.0.0",
     "jsxcs": "^0.2.1",
     "react": "^16.2.0"
   }


### PR DESCRIPTION
This Pull Request updates dependency [firebase](https://github.com/firebase/firebase-js-sdk) from `^4.9.0` to `^5.0.0`



<details>
<summary>Release Notes</summary>

### [`v5.0.1`](https://github.com/firebase/firebase-js-sdk/compare/8922c3aeaf74493e1aefc4edd54e85606442479e...9c953fa337f4e6e4cbcdf67e32888bea349be377)
[Compare Source](https://github.com/firebase/firebase-js-sdk/compare/8922c3aeaf74493e1aefc4edd54e85606442479e...9c953fa337f4e6e4cbcdf67e32888bea349be377)


---

### [`v5.0.0`](https://github.com/firebase/firebase-js-sdk/compare/9c953fa337f4e6e4cbcdf67e32888bea349be377...6003c32e9d80b3c1a09600e8f2b999623febb748)
[Compare Source](https://github.com/firebase/firebase-js-sdk/compare/9c953fa337f4e6e4cbcdf67e32888bea349be377...6003c32e9d80b3c1a09600e8f2b999623febb748)


---

</details>